### PR TITLE
chore: 개발용 securityConfig작성 및 어노테이션 추가

### DIFF
--- a/src/main/java/com/kdev5/cleanpick/CleanpickApplication.java
+++ b/src/main/java/com/kdev5/cleanpick/CleanpickApplication.java
@@ -2,7 +2,9 @@ package com.kdev5.cleanpick;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CleanpickApplication {
 

--- a/src/main/java/com/kdev5/cleanpick/global/SecurityConfig.java
+++ b/src/main/java/com/kdev5/cleanpick/global/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.kdev5.cleanpick.global;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request ->
+                        request.anyRequest().permitAll()) // ✅ 모든 요청 허용
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable);
+
+        return httpSecurity.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedHeaders(Collections.singletonList("*"));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedOriginPatterns(Collections.singletonList("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/kdev5/cleanpick/global/response/ApiResponse.java
+++ b/src/main/java/com/kdev5/cleanpick/global/response/ApiResponse.java
@@ -3,7 +3,9 @@ package com.kdev5.cleanpick.global.response;
 import com.kdev5.cleanpick.global.exception.ErrorCode;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 


### PR DESCRIPTION
# Pull Request
## 📝 PR 설명

- 개발 편의를 위해 임시로 security permit all 설정
- baseTimeEntity 자동 설정 관련 어노테이션 추가(@EnableJpaAuditing) 
- response응답 깨짐 방지를 위한 @ Getter 어노테이션 추가

---

## ✅ 작업 내용 체크리스트

- [ ] 새로운 기능 추가
- [ ] 기존 기능 수정
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서/README 수정
- [x] 기타

---

## 🔍 관련 이슈

- 관련된 이슈 번호 또는 설명을 연결해 주세요.
    - resolves #6

---

## 🧩 참고 자료 (선택)

- API 명세서, 디자인 링크, 노션 문서 등