### PR TITLE
Feature/4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/resources/*.yml
+src/main/resources/data.sql
 node_mudules/
 a
 ### STS ###

--- a/src/main/java/com/kdev5/cleanpick/manager/controller/ManagerController.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/controller/ManagerController.java
@@ -2,8 +2,9 @@ package com.kdev5.cleanpick.manager.controller;
 
 import com.kdev5.cleanpick.global.response.ApiResponse;
 import com.kdev5.cleanpick.global.response.PageResponse;
+import com.kdev5.cleanpick.manager.domain.enumeration.SortType;
 import com.kdev5.cleanpick.manager.service.ManagerService;
-import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerSearchResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,24 +16,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/manager")
+@RequestMapping("/manager")
 public class ManagerController {
 
     private final ManagerService managerService;
 
-    @GetMapping("")
-    public ResponseEntity<ApiResponse<PageResponse<ManagerResponseDto>>> searchManager (
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<PageResponse<ManagerSearchResponseDto>>> search (
             @RequestParam(required = false)
             String cleaning,
             @RequestParam(required = false)
             String region,
             @RequestParam(required = false)
             String keyword,                             // 검색어
-            @RequestParam(defaultValue = "추천순")
-            String sortType,
+            @RequestParam(defaultValue = "RECOMMENDATION")
+            SortType sortType,
             Pageable pageable
     ) {
-        Page<ManagerResponseDto> result = managerService.searchManagers(cleaning, region, keyword, sortType, pageable);
+        Page<ManagerSearchResponseDto> result = managerService.searchManagers(cleaning, region, keyword, sortType, pageable);
         return ResponseEntity.ok(ApiResponse.ok(new PageResponse<>(result)));
     }
 }

--- a/src/main/java/com/kdev5/cleanpick/manager/controller/ManagerController.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/controller/ManagerController.java
@@ -1,0 +1,38 @@
+package com.kdev5.cleanpick.manager.controller;
+
+import com.kdev5.cleanpick.global.response.ApiResponse;
+import com.kdev5.cleanpick.global.response.PageResponse;
+import com.kdev5.cleanpick.manager.service.ManagerService;
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/manager")
+public class ManagerController {
+
+    private final ManagerService managerService;
+
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<PageResponse<ManagerResponseDto>>> searchManager (
+            @RequestParam(required = false)
+            String cleaning,
+            @RequestParam(required = false)
+            String region,
+            @RequestParam(required = false)
+            String keyword,                             // 검색어
+            @RequestParam(defaultValue = "추천순")
+            String sortType,
+            Pageable pageable
+    ) {
+        Page<ManagerResponseDto> result = managerService.searchManagers(cleaning, region, keyword, sortType, pageable);
+        return ResponseEntity.ok(ApiResponse.ok(new PageResponse<>(result)));
+    }
+}

--- a/src/main/java/com/kdev5/cleanpick/manager/domain/enumeration/SortType.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/domain/enumeration/SortType.java
@@ -1,0 +1,7 @@
+package com.kdev5.cleanpick.manager.domain.enumeration;
+
+public enum SortType {
+    RECOMMENDATION,
+    STAR,
+    REVIEW_COUNT
+}

--- a/src/main/java/com/kdev5/cleanpick/manager/infra/querydsl/ManagerRepositoryCustom.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/infra/querydsl/ManagerRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.kdev5.cleanpick.manager.infra.querydsl;
+
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+public interface ManagerRepositoryCustom {
+
+    Page<ManagerResponseDto> searchManagers(String cleaning, String region, String keyword, String sortType, Pageable pageable);
+
+}

--- a/src/main/java/com/kdev5/cleanpick/manager/infra/querydsl/ManagerRepositoryCustom.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/infra/querydsl/ManagerRepositoryCustom.java
@@ -1,12 +1,13 @@
 package com.kdev5.cleanpick.manager.infra.querydsl;
 
-import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import com.kdev5.cleanpick.manager.domain.enumeration.SortType;
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerSearchResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 
 public interface ManagerRepositoryCustom {
 
-    Page<ManagerResponseDto> searchManagers(String cleaning, String region, String keyword, String sortType, Pageable pageable);
+    Page<ManagerSearchResponseDto> searchManagers(String cleaning, String region, String keyword, SortType sortType, Pageable pageable);
 
 }

--- a/src/main/java/com/kdev5/cleanpick/manager/infra/querydsl/ManagerRepositoryImpl.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/infra/querydsl/ManagerRepositoryImpl.java
@@ -1,0 +1,220 @@
+package com.kdev5.cleanpick.manager.infra.querydsl;
+
+
+import com.kdev5.cleanpick.cleaning.domain.QCleaning;
+import com.kdev5.cleanpick.manager.domain.*;
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import com.kdev5.cleanpick.review.domain.QReview;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import static com.kdev5.cleanpick.review.domain.enumeration.ReviewType.TO_MANAGER;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class ManagerRepositoryImpl implements ManagerRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ManagerResponseDto> searchManagers(
+            String cleaning,
+            String region,
+            String keyword,
+            String sortType,
+            Pageable pageable
+    ) {
+        QManager manager = QManager.manager;
+        QReview review = QReview.review;
+        QManagerAvailableCleaning mac = QManagerAvailableCleaning.managerAvailableCleaning;
+        QCleaning cleaningEntity = QCleaning.cleaning;
+        QManagerAvailableRegion mar = QManagerAvailableRegion.managerAvailableRegion;
+        QRegion regionEntity = QRegion.region;
+
+        //기본 쿼리 생성
+        JPQLQuery<Manager> baseQuery = queryFactory
+                .selectFrom(manager)
+                .distinct();
+
+        //클리닝 필터 적용 쿼리 생성
+        if (cleaning != null) {
+            baseQuery
+                    .join(mac).on(mac.manager.eq(manager))
+                    .join(mac.cleaning, cleaningEntity)
+                    .where(cleaningEntity.serviceName.eq(cleaning));
+        }
+
+        //지역 필터 적용 쿼리 생성
+        if (region != null) {
+            baseQuery
+                    .join(mar).on(mar.manager.eq(manager))
+                    .join(mar.region, regionEntity)
+                    .where(regionEntity.name.eq(region));
+        }
+
+        //검색어 적용 쿼리 생성
+        if (keyword != null && !keyword.isBlank()) {
+            baseQuery.where(manager.name.containsIgnoreCase(keyword));
+        }
+
+        //정렬 타입 적용 쿼리 생성
+        baseQuery.orderBy(getOrderSpecifier(sortType, review, manager));
+
+        //페이징 위해 검색된 전체 row 수 저장
+        long total = baseQuery.fetchCount();
+
+        //페이징 처리
+        List<Manager> managers = baseQuery
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        List<Long> managerIds = managers.stream().map(Manager::getId).toList();
+
+        Map<Long, Double> avgMap = new HashMap<>();
+        Map<Long, Long> countMap = new HashMap<>();
+        loadReviewStats(managerIds, avgMap, countMap);
+
+        Map<Long, List<String>> regionMap = loadManagerRegions(managerIds);
+        Map<Long, List<String>> cleaningMap = loadManagerCleanings(managerIds);
+
+        //엔티티 -> response dto 맵핑
+        List<ManagerResponseDto> content = managers.stream()
+                .map(m -> new ManagerResponseDto(
+                        m.getId(),
+                        m.getName(),
+                        avgMap.getOrDefault(m.getId(), 0.0),
+                        countMap.getOrDefault(m.getId(), 0L),
+                        m.getProfileImageUrl(),
+                        m.getProfileMessage(),
+                        extractRegionSummary(m.getId(), region, regionMap),
+                        cleaningMap.getOrDefault(m.getId(), List.of())
+                ))
+                .toList();
+        //dto + 페이징데이터 리턴
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private void loadReviewStats(List<Long> managerIds, Map<Long, Double> avgMap, Map<Long, Long> countMap) {
+        QReview review = QReview.review;
+
+        List<Tuple> result = queryFactory
+                .select(review.manager.id, review.rating.avg(), review.count())
+                .from(review)
+                .where(
+                        review.manager.id.in(managerIds)
+                                .and(review.type.eq(TO_MANAGER))
+                )
+                .groupBy(review.manager.id)
+                .fetch();
+
+        for (Tuple tuple : result) {
+            Long id = tuple.get(review.manager.id);
+            Double avg = tuple.get(review.rating.avg());
+            Long cnt = tuple.get(review.count());
+            avgMap.put(id, avg != null ? avg : 0.0);
+            countMap.put(id, cnt != null ? cnt : 0L);
+        }
+    }
+
+    private Map<Long, List<String>> loadManagerRegions(List<Long> managerIds) {
+        QManagerAvailableRegion mar = QManagerAvailableRegion.managerAvailableRegion;
+        QRegion region = QRegion.region;
+
+        List<Tuple> result = queryFactory
+                .select(mar.manager.id, region.name)
+                .from(mar)
+                .join(mar.region, region)
+                .where(mar.manager.id.in(managerIds))
+                .fetch();
+
+        return result.stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(mar.manager.id),
+                        Collectors.mapping(tuple -> tuple.get(region.name), Collectors.toList())
+                ));
+    }
+
+    private Map<Long, List<String>> loadManagerCleanings(List<Long> managerIds) {
+        QManagerAvailableCleaning mac = QManagerAvailableCleaning.managerAvailableCleaning;
+        QCleaning cleaning = QCleaning.cleaning;
+
+        List<Tuple> result = queryFactory
+                .select(mac.manager.id, cleaning.serviceName)
+                .from(mac)
+                .join(mac.cleaning, cleaning)
+                .where(mac.manager.id.in(managerIds))
+                .fetch();
+
+        return result.stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(mac.manager.id),
+                        Collectors.mapping(tuple -> tuple.get(cleaning.serviceName), Collectors.toList())
+                ));
+    }
+
+    private String extractRegionSummary(Long managerId, String regionFilter, Map<Long, List<String>> regionMap) {
+        List<String> regionNames = regionMap.getOrDefault(managerId, List.of());
+
+        if (regionFilter != null && regionNames.contains(regionFilter)) {
+            long others = regionNames.stream()
+                    .filter(name -> !name.equals(regionFilter))
+                    .count();
+            return others == 0 ? regionFilter : regionFilter + " 외 " + others + "곳";
+        }
+
+        return regionNames.isEmpty() ? "" : regionNames.get(0);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sortType, QReview review, QManager manager) {
+        switch (sortType) {
+            case "평점순" -> {
+                return new OrderSpecifier<>(
+                        Order.DESC,
+                        JPAExpressions.select(review.rating.avg().coalesce(0.0))
+                                .from(review)
+                                .where(
+                                        review.manager.eq(manager)
+                                                .and(review.type.eq(TO_MANAGER))
+                                )
+                );
+            }
+            case "리뷰많은순" -> {
+                return new OrderSpecifier<>(
+                        Order.DESC,
+                        JPAExpressions.select(review.count().coalesce(0L))
+                                .from(review)
+                                .where(
+                                        review.manager.eq(manager)
+                                                .and(review.type.eq(TO_MANAGER))
+                                )
+                );
+            }
+            default -> {
+                NumberExpression<Double> score = review.rating.avg().coalesce(0.0).multiply(0.7)
+                        .add(review.count().doubleValue().multiply(0.3));
+                return new OrderSpecifier<>(
+                        Order.DESC,
+                        JPAExpressions.select(score)
+                                .from(review)
+                                .where(
+                                        review.manager.eq(manager)
+                                                .and(review.type.eq(TO_MANAGER))
+                                )
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/com/kdev5/cleanpick/manager/infra/repository/ManagerRepository.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/infra/repository/ManagerRepository.java
@@ -1,11 +1,14 @@
 package com.kdev5.cleanpick.manager.infra.repository;
 
 import com.kdev5.cleanpick.manager.domain.Manager;
+import com.kdev5.cleanpick.manager.infra.querydsl.ManagerRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-public interface ManagerRepository extends JpaRepository<Manager, Long> {
+@Repository
+public interface ManagerRepository extends JpaRepository<Manager, Long>, ManagerRepositoryCustom {
 
     public Optional<Manager> findByUserId(Long userId);
 

--- a/src/main/java/com/kdev5/cleanpick/manager/service/ManagerService.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/service/ManagerService.java
@@ -1,8 +1,8 @@
 package com.kdev5.cleanpick.manager.service;
 
-import com.kdev5.cleanpick.manager.infra.querydsl.ManagerRepositoryCustom;
+import com.kdev5.cleanpick.manager.domain.enumeration.SortType;
 import com.kdev5.cleanpick.manager.infra.repository.ManagerRepository;
-import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerSearchResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,12 +14,12 @@ public class ManagerService {
 
     private final ManagerRepository managerRepository;
 
-    // 매니저 검색 및 필터
-    public Page<ManagerResponseDto> searchManagers(
+    // 필터, 검색, 정렬을 적용한 매니저 리스트 반환
+    public Page<ManagerSearchResponseDto> searchManagers(
             String serviceType,
             String region,
             String keyword,
-            String sortType,
+            SortType sortType,
             Pageable pageable
     ) {
         return managerRepository.searchManagers(serviceType, region, keyword, sortType, pageable);

--- a/src/main/java/com/kdev5/cleanpick/manager/service/ManagerService.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/service/ManagerService.java
@@ -1,0 +1,29 @@
+package com.kdev5.cleanpick.manager.service;
+
+import com.kdev5.cleanpick.manager.infra.querydsl.ManagerRepositoryCustom;
+import com.kdev5.cleanpick.manager.infra.repository.ManagerRepository;
+import com.kdev5.cleanpick.manager.service.dto.response.ManagerResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerService {
+
+    private final ManagerRepository managerRepository;
+
+    // 매니저 검색 및 필터
+    public Page<ManagerResponseDto> searchManagers(
+            String serviceType,
+            String region,
+            String keyword,
+            String sortType,
+            Pageable pageable
+    ) {
+        return managerRepository.searchManagers(serviceType, region, keyword, sortType, pageable);
+    }
+
+
+}

--- a/src/main/java/com/kdev5/cleanpick/manager/service/dto/response/ManagerResponseDto.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/service/dto/response/ManagerResponseDto.java
@@ -1,0 +1,16 @@
+package com.kdev5.cleanpick.manager.service.dto.response;
+
+import java.util.List;
+
+public record ManagerResponseDto(
+        Long id,
+        String name,
+        double averageRating,
+        long reviewCount,
+        String profileImageUrl,
+        String profileMessage,
+        String regionSummary,              // 추가
+        List<String> cleaningServices
+) {
+
+}

--- a/src/main/java/com/kdev5/cleanpick/manager/service/dto/response/ManagerSearchResponseDto.java
+++ b/src/main/java/com/kdev5/cleanpick/manager/service/dto/response/ManagerSearchResponseDto.java
@@ -2,7 +2,7 @@ package com.kdev5.cleanpick.manager.service.dto.response;
 
 import java.util.List;
 
-public record ManagerResponseDto(
+public record ManagerSearchResponseDto(
         Long id,
         String name,
         double averageRating,


### PR DESCRIPTION
# Pull Request
## 📝 PR 설명

- 조건(필터, 검색, 정렬)에 맞는 매니저 리스트 반환하는 api 구현입니다
- 정렬은 추천순(별점순*0.7 + 리뷰많은순*0.3 의 가중치 고려), 별점순, 리뷰많은순으로 구성했습니다
- 매니저를 조회할때 가능 지역이 여러 곳인 경우, {customer가 검색한 지역 외 n곳} 형식의 문자열을 반환하도록 하였습니다
---

## ✅ 작업 내용 체크리스트

- [x] 이름으로 검색 api
- [x] 지역, 서비스 필터 api
- [x] 정렬

---

## 🔍 관련 이슈

- 관련된 이슈 번호 또는 설명을 연결해 주세요.
    -  #4

---

## 🧩 참고 자료 (선택)
