### PR TITLE
Feature/31

### DIFF
--- a/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
@@ -21,4 +21,11 @@ public class MatchingController {
         contractMatchingService.rejectMatchingRequest(managerId, contractId);
         return ResponseEntity.ok(ApiResponse.ok());
     }
+
+    @PatchMapping("/{contractId}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptMatchingRequest(@PathVariable("contractId") Long contractId) {
+        Long managerId = 1L; //TODO: 추후 연결
+        contractMatchingService.acceptMatchingRequest(managerId, contractId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
 }

--- a/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
@@ -1,5 +1,6 @@
 package com.kdev5.cleanpick.contract.controller;
 
+import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
 import com.kdev5.cleanpick.contract.service.ContractMatchingService;
 import com.kdev5.cleanpick.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +15,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/matching")
 public class MatchingController {
     private final ContractMatchingService contractMatchingService;
-
+    
     @PatchMapping("/{contractId}/reject")
     public ResponseEntity<ApiResponse<Void>> rejectMatchingRequest(@PathVariable("contractId") Long contractId) {
         Long managerId = 1L; //TODO: 추후 연결
-        contractMatchingService.rejectMatchingRequest(managerId, contractId);
+        contractMatchingService.updateMatchingStatus(managerId, contractId, MatchingStatus.REJECT);
         return ResponseEntity.ok(ApiResponse.ok());
     }
 
     @PatchMapping("/{contractId}/accept")
     public ResponseEntity<ApiResponse<Void>> acceptMatchingRequest(@PathVariable("contractId") Long contractId) {
         Long managerId = 1L; //TODO: 추후 연결
-        contractMatchingService.acceptMatchingRequest(managerId, contractId);
+        contractMatchingService.updateMatchingStatus(managerId, contractId, MatchingStatus.ACCEPT);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @PatchMapping("/{contractId}/accept-personal")
+    public ResponseEntity<ApiResponse<Void>> acceptPersonalMatchingRequest(@PathVariable("contractId") Long contractId) {
+        Long managerId = 1L; //TODO: 추후 연결
+        contractMatchingService.matchManagerAndCustomer(managerId, contractId);
         return ResponseEntity.ok(ApiResponse.ok());
     }
 }

--- a/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
@@ -1,11 +1,13 @@
 package com.kdev5.cleanpick.contract.controller;
 
-import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
 import com.kdev5.cleanpick.contract.service.ContractMatchingService;
 import com.kdev5.cleanpick.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,21 +15,35 @@ import org.springframework.web.bind.annotation.*;
 public class MatchingController {
     private final ContractMatchingService contractMatchingService;
 
-    @PatchMapping("/{contractId}")
-    public ResponseEntity<ApiResponse<Void>> updateMatchingStatus(
-            @PathVariable Long contractId,
-            @RequestParam MatchingStatus status) {
+    @PatchMapping("/{contractId}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptMatching(@PathVariable Long contractId) {
 
         Long managerId = 1L; // TODO: 추후 연결
-        contractMatchingService.updateMatchingStatus(managerId, contractId, status);
+        contractMatchingService.acceptMatching(managerId, contractId);
 
         return ResponseEntity.ok(ApiResponse.ok());
     }
 
-    @PatchMapping("/{contractId}/accept-personal")
-    public ResponseEntity<ApiResponse<Void>> acceptPersonalMatchingRequest(@PathVariable("contractId") Long contractId) {
+    @PatchMapping("/{contractId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectMatching(@PathVariable Long contractId) {
+
+        Long managerId = 1L; // TODO: 추후 연결
+        contractMatchingService.rejectMatching(managerId, contractId);
+
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @PatchMapping("/{contractId}/reject-personal")
+    public ResponseEntity<ApiResponse<Void>> rejectPersonalMatchingRequest(@PathVariable("contractId") Long contractId) {
         Long managerId = 1L; //TODO: 추후 연결
-        contractMatchingService.matchManagerAndCustomer(managerId, contractId);
+        contractMatchingService.rejectPersonalMatching(managerId, contractId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @PatchMapping("/{contractId}/accept-personal")
+    public ResponseEntity<ApiResponse<Void>> acceptPersonalMatching(@PathVariable("contractId") Long contractId) {
+        Long managerId = 1L; //TODO: 추후 연결
+        contractMatchingService.acceptPersonalMatching(managerId, contractId);
         return ResponseEntity.ok(ApiResponse.ok());
     }
 }

--- a/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
@@ -1,0 +1,24 @@
+package com.kdev5.cleanpick.contract.controller;
+
+import com.kdev5.cleanpick.contract.service.ContractMatchingService;
+import com.kdev5.cleanpick.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/matching")
+public class MatchingController {
+    private final ContractMatchingService contractMatchingService;
+
+    @PatchMapping("/{contractId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectMatchingRequest(@PathVariable("contractId") Long contractId) {
+        Long managerId = 1L; //TODO: 추후 연결
+        contractMatchingService.rejectMatchingRequest(managerId, contractId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/controller/MatchingController.java
@@ -5,28 +5,22 @@ import com.kdev5.cleanpick.contract.service.ContractMatchingService;
 import com.kdev5.cleanpick.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/matching")
 public class MatchingController {
     private final ContractMatchingService contractMatchingService;
-    
-    @PatchMapping("/{contractId}/reject")
-    public ResponseEntity<ApiResponse<Void>> rejectMatchingRequest(@PathVariable("contractId") Long contractId) {
-        Long managerId = 1L; //TODO: 추후 연결
-        contractMatchingService.updateMatchingStatus(managerId, contractId, MatchingStatus.REJECT);
-        return ResponseEntity.ok(ApiResponse.ok());
-    }
 
-    @PatchMapping("/{contractId}/accept")
-    public ResponseEntity<ApiResponse<Void>> acceptMatchingRequest(@PathVariable("contractId") Long contractId) {
-        Long managerId = 1L; //TODO: 추후 연결
-        contractMatchingService.updateMatchingStatus(managerId, contractId, MatchingStatus.ACCEPT);
+    @PatchMapping("/{contractId}")
+    public ResponseEntity<ApiResponse<Void>> updateMatchingStatus(
+            @PathVariable Long contractId,
+            @RequestParam MatchingStatus status) {
+
+        Long managerId = 1L; // TODO: 추후 연결
+        contractMatchingService.updateMatchingStatus(managerId, contractId, status);
+
         return ResponseEntity.ok(ApiResponse.ok());
     }
 

--- a/src/main/java/com/kdev5/cleanpick/contract/domain/Contract.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/domain/Contract.java
@@ -70,4 +70,8 @@ public class Contract extends BaseTimeEntity {
         this.personal = personal;
         this.status = status;
     }
+
+    public void updateManager(Manager manager) {
+        this.manager = manager;
+    }
 }

--- a/src/main/java/com/kdev5/cleanpick/contract/domain/Nominee.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/domain/Nominee.java
@@ -16,11 +16,11 @@ public class Nominee extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "contract_id", nullable = false)
     private Contract contract;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id", nullable = false)
     private Manager manager;
 

--- a/src/main/java/com/kdev5/cleanpick/contract/domain/Nominee.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/domain/Nominee.java
@@ -1,5 +1,6 @@
 package com.kdev5.cleanpick.contract.domain;
 
+import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
 import com.kdev5.cleanpick.global.entity.BaseTimeEntity;
 import com.kdev5.cleanpick.manager.domain.Manager;
 import jakarta.persistence.*;
@@ -23,14 +24,19 @@ public class Nominee extends BaseTimeEntity {
     @JoinColumn(name = "manager_id", nullable = false)
     private Manager manager;
 
-    @Column(name = "is_accepted", nullable = false)
-    private boolean isAccepted;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MatchingStatus status;
 
     @Builder
-    public Nominee(Contract contract, Manager manager, boolean isAccepted) {
+    public Nominee(Contract contract, Manager manager) {
         this.contract = contract;
         this.manager = manager;
-        this.isAccepted = isAccepted;
+        this.status = MatchingStatus.PENDING;
+    }
+
+    public void updateStatus(MatchingStatus status) {
+        this.status = status;
     }
 }
 

--- a/src/main/java/com/kdev5/cleanpick/contract/domain/enumeration/MatchingStatus.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/domain/enumeration/MatchingStatus.java
@@ -1,0 +1,5 @@
+package com.kdev5.cleanpick.contract.domain.enumeration;
+
+public enum MatchingStatus {
+    ACCEPT, REJECT, PENDING
+}

--- a/src/main/java/com/kdev5/cleanpick/contract/domain/exception/NomineeException.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/domain/exception/NomineeException.java
@@ -1,0 +1,11 @@
+package com.kdev5.cleanpick.contract.domain.exception;
+
+import com.kdev5.cleanpick.global.exception.BaseException;
+import com.kdev5.cleanpick.global.exception.ErrorCode;
+
+public class NomineeException extends BaseException {
+
+    public NomineeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kdev5/cleanpick/contract/infra/NomineeRepository.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/infra/NomineeRepository.java
@@ -2,8 +2,13 @@ package com.kdev5.cleanpick.contract.infra;
 
 import com.kdev5.cleanpick.contract.domain.Nominee;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface NomineeRepository extends JpaRepository<Nominee, Long> {
+    @Query("SELECT n FROM Nominee n WHERE n.manager.id = :managerId AND n.contract.id = :contractId")
+    Optional<Nominee> findByContractAndManager(Long managerId, Long contractId);
 }

--- a/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
@@ -16,8 +16,19 @@ public class ContractMatchingService {
 
     @Transactional
     public void rejectMatchingRequest(Long managerId, Long contractId) {
-        Nominee nominee = nomineeRepository.findByContractAndManager(managerId, contractId).orElseThrow(() -> new NomineeException(ErrorCode.MATCHING_NOMINEE_NOT_FOUND));
+        Nominee nominee = getNominee(managerId, contractId);
         nominee.updateStatus(MatchingStatus.REJECT);
         nomineeRepository.save(nominee);
+    }
+
+    @Transactional
+    public void acceptMatchingRequest(Long managerId, Long contractId) {
+        Nominee nominee = getNominee(managerId, contractId);
+        nominee.updateStatus(MatchingStatus.ACCEPT);
+        nomineeRepository.save(nominee);
+    }
+
+    private Nominee getNominee(Long managerId, Long contractId) {
+        return nomineeRepository.findByContractAndManager(managerId, contractId).orElseThrow(() -> new NomineeException(ErrorCode.MATCHING_NOMINEE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
@@ -1,10 +1,16 @@
 package com.kdev5.cleanpick.contract.service;
 
+import com.kdev5.cleanpick.contract.domain.Contract;
 import com.kdev5.cleanpick.contract.domain.Nominee;
 import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
+import com.kdev5.cleanpick.contract.domain.exception.ContractException;
 import com.kdev5.cleanpick.contract.domain.exception.NomineeException;
+import com.kdev5.cleanpick.contract.infra.ContractRepository;
 import com.kdev5.cleanpick.contract.infra.NomineeRepository;
 import com.kdev5.cleanpick.global.exception.ErrorCode;
+import com.kdev5.cleanpick.manager.domain.Manager;
+import com.kdev5.cleanpick.manager.domain.exception.ManagerNotFoundException;
+import com.kdev5.cleanpick.manager.infra.repository.ManagerRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,19 +19,29 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ContractMatchingService {
     private final NomineeRepository nomineeRepository;
+    private final ContractRepository contractRepository;
+    private final ManagerRepository managerRepository;
 
     @Transactional
-    public void rejectMatchingRequest(Long managerId, Long contractId) {
+    public void updateMatchingStatus(Long managerId, Long contractId, MatchingStatus status) {
         Nominee nominee = getNominee(managerId, contractId);
-        nominee.updateStatus(MatchingStatus.REJECT);
+        nominee.updateStatus(status);
         nomineeRepository.save(nominee);
     }
 
     @Transactional
-    public void acceptMatchingRequest(Long managerId, Long contractId) {
-        Nominee nominee = getNominee(managerId, contractId);
-        nominee.updateStatus(MatchingStatus.ACCEPT);
-        nomineeRepository.save(nominee);
+    public void matchManagerAndCustomer(Long managerId, Long contractId) {
+        updateMatchingStatus(managerId, contractId, MatchingStatus.ACCEPT);
+
+        Manager manager = managerRepository.findById(managerId)
+                .orElseThrow(() -> new ManagerNotFoundException(ErrorCode.MANAGER_NOT_FOUND));
+        Contract contract = contractRepository.findById(contractId)
+                .orElseThrow(() -> new ContractException(ErrorCode.CONTRACT_NOT_FOUND));
+
+        if (!contract.isPersonal()) throw new ContractException(ErrorCode.CONTRACT_BAD_REQUEST);
+
+        contract.updateManager(manager);
+        contractRepository.save(contract);
     }
 
     private Nominee getNominee(Long managerId, Long contractId) {

--- a/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
@@ -1,0 +1,23 @@
+package com.kdev5.cleanpick.contract.service;
+
+import com.kdev5.cleanpick.contract.domain.Nominee;
+import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
+import com.kdev5.cleanpick.contract.domain.exception.NomineeException;
+import com.kdev5.cleanpick.contract.infra.NomineeRepository;
+import com.kdev5.cleanpick.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ContractMatchingService {
+    private final NomineeRepository nomineeRepository;
+
+    @Transactional
+    public void rejectMatchingRequest(Long managerId, Long contractId) {
+        Nominee nominee = nomineeRepository.findByContractAndManager(managerId, contractId).orElseThrow(() -> new NomineeException(ErrorCode.MATCHING_NOMINEE_NOT_FOUND));
+        nominee.updateStatus(MatchingStatus.REJECT);
+        nomineeRepository.save(nominee);
+    }
+}

--- a/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
+++ b/src/main/java/com/kdev5/cleanpick/contract/service/ContractMatchingService.java
@@ -23,15 +23,22 @@ public class ContractMatchingService {
     private final ManagerRepository managerRepository;
 
     @Transactional
-    public void updateMatchingStatus(Long managerId, Long contractId, MatchingStatus status) {
+    public void acceptMatching(Long managerId, Long contractId) {
         Nominee nominee = getNominee(managerId, contractId);
-        nominee.updateStatus(status);
+        nominee.updateStatus(MatchingStatus.ACCEPT);
         nomineeRepository.save(nominee);
     }
 
     @Transactional
-    public void matchManagerAndCustomer(Long managerId, Long contractId) {
-        updateMatchingStatus(managerId, contractId, MatchingStatus.ACCEPT);
+    public void rejectMatching(Long managerId, Long contractId) {
+        Nominee nominee = getNominee(managerId, contractId);
+        nominee.updateStatus(MatchingStatus.REJECT);
+        nomineeRepository.save(nominee);
+    }
+
+    @Transactional
+    public void acceptPersonalMatching(Long managerId, Long contractId) {
+        acceptMatching(managerId, contractId);
 
         Manager manager = managerRepository.findById(managerId)
                 .orElseThrow(() -> new ManagerNotFoundException(ErrorCode.MANAGER_NOT_FOUND));
@@ -42,6 +49,14 @@ public class ContractMatchingService {
 
         contract.updateManager(manager);
         contractRepository.save(contract);
+
+        //TODO: 알림 로직
+    }
+
+    @Transactional
+    public void rejectPersonalMatching(Long managerId, Long contractId) {
+        rejectMatching(managerId, contractId);
+        //TODO: 알림 로직
     }
 
     private Nominee getNominee(Long managerId, Long contractId) {

--- a/src/main/java/com/kdev5/cleanpick/global/exception/ErrorCode.java
+++ b/src/main/java/com/kdev5/cleanpick/global/exception/ErrorCode.java
@@ -12,9 +12,10 @@ public enum ErrorCode {
     MANAGER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MANAGER_NOT_FOUND", "존재하지 않는 매니저입니다."),
     CLEANING_NOT_FOUND(HttpStatus.BAD_REQUEST, "CLEANING_NOT_FOUND", "존재하지 않는 청소입니다."),
     CUSTOMER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CUSTOMER_NOT_FOUND", "존재하지 않는 고객입니다."),
-    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST , "REVIEW_ALREADY_EXISTS", "존재하지 않는 리뷰입니다." ),
-    CLEANING_OPTION_NOT_FOUND(HttpStatus.BAD_REQUEST , "CLEANING_OPTION_NOT_FOUND", "존재하지 않는 청소 요구사항입니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "입력 정보가 잘못되었습니다.");
+    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REVIEW_ALREADY_EXISTS", "존재하지 않는 리뷰입니다."),
+    CLEANING_OPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "CLEANING_OPTION_NOT_FOUND", "존재하지 않는 청소 요구사항입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "입력 정보가 잘못되었습니다."),
+    MATCHING_NOMINEE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MATCHING_NOMINEE_NOT_FOUND", "존재하지 않는 매칭 요청입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kdev5/cleanpick/global/exception/ErrorCode.java
+++ b/src/main/java/com/kdev5/cleanpick/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "EMAIL_ALREADY_EXISTS", "이미 가입된 이메일입니다."),
     CONTRACT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CONTRACT_NOT_FOUND", "계약을 찾을 수 없습니다."),
+    CONTRACT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "CONTRACT_BAD_REQUEST", "1:1 계약이 아닙니다."),
     MANAGER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MANAGER_NOT_FOUND", "존재하지 않는 매니저입니다."),
     CLEANING_NOT_FOUND(HttpStatus.BAD_REQUEST, "CLEANING_NOT_FOUND", "존재하지 않는 청소입니다."),
     CUSTOMER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CUSTOMER_NOT_FOUND", "존재하지 않는 고객입니다."),

--- a/src/main/java/com/kdev5/cleanpick/global/response/ApiResponse.java
+++ b/src/main/java/com/kdev5/cleanpick/global/response/ApiResponse.java
@@ -20,9 +20,14 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, data, "SUCCESS", "요청에 성공하였습니다.");
     }
 
+    // 요청 성공한 경우
+    public static <T> ApiResponse<T> ok() {
+        return new ApiResponse<>(true, null, "SUCCESS", "요청에 성공하였습니다.");
+    }
+
     //단순 에러
     public static ApiResponse<?> error(ErrorCode errorCode) {
-        return new ApiResponse<>(false, null, errorCode.getCode() ,errorCode.getMessage());
+        return new ApiResponse<>(false, null, errorCode.getCode(), errorCode.getMessage());
     }
 
     //에러 + 데이터

--- a/src/test/java/com/kdev5/cleanpick/contract/service/ContractMatchingServiceTest.java
+++ b/src/test/java/com/kdev5/cleanpick/contract/service/ContractMatchingServiceTest.java
@@ -4,103 +4,96 @@ import com.kdev5.cleanpick.contract.domain.Contract;
 import com.kdev5.cleanpick.contract.domain.Nominee;
 import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
 import com.kdev5.cleanpick.contract.domain.exception.ContractException;
-import com.kdev5.cleanpick.contract.domain.exception.NomineeException;
 import com.kdev5.cleanpick.contract.infra.ContractRepository;
 import com.kdev5.cleanpick.contract.infra.NomineeRepository;
 import com.kdev5.cleanpick.global.exception.ErrorCode;
 import com.kdev5.cleanpick.manager.domain.Manager;
 import com.kdev5.cleanpick.manager.infra.repository.ManagerRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 class ContractMatchingServiceTest {
 
+    @Mock
     private NomineeRepository nomineeRepository;
+
+    @Mock
     private ContractRepository contractRepository;
+
+    @Mock
     private ManagerRepository managerRepository;
+
+    @InjectMocks
     private ContractMatchingService contractMatchingService;
+
+    private final Long managerId = 1L;
+    private final Long contractId = 100L;
+
+    private Nominee nominee;
+    private Manager manager;
+    private Contract contract;
 
     @BeforeEach
     void setUp() {
-        nomineeRepository = mock(NomineeRepository.class);
-        contractRepository = mock(ContractRepository.class);
-        managerRepository = mock(ManagerRepository.class);
-        contractMatchingService = new ContractMatchingService(nomineeRepository, contractRepository, managerRepository);
+        MockitoAnnotations.openMocks(this);
+
+        nominee = mock(Nominee.class);
+        manager = mock(Manager.class);
+        contract = mock(Contract.class);
     }
 
     @Test
-    @DisplayName("updateMatchingStatus - 정상 동작")
-    void updateMatchingStatus_success() {
-        Long managerId = 1L;
-        Long contractId = 1L;
-        Nominee nominee = mock(Nominee.class);
+    void acceptPersonalMatching_정상_호출() {
+        // given
+        given(nomineeRepository.findByContractAndManager(managerId, contractId)).willReturn(Optional.of(nominee));
+        given(managerRepository.findById(managerId)).willReturn(Optional.of(manager));
+        given(contractRepository.findById(contractId)).willReturn(Optional.of(contract));
+        given(contract.isPersonal()).willReturn(true);
 
-        when(nomineeRepository.findByContractAndManager(managerId, contractId))
-                .thenReturn(Optional.of(nominee));
+        // when
+        contractMatchingService.acceptPersonalMatching(managerId, contractId);
 
-        contractMatchingService.updateMatchingStatus(managerId, contractId, MatchingStatus.REJECT);
-
-        verify(nominee).updateStatus(MatchingStatus.REJECT);
-        verify(nomineeRepository).save(nominee);
+        // then
+        then(nominee).should().updateStatus(MatchingStatus.ACCEPT);
+        then(nomineeRepository).should().save(nominee);
+        then(contract).should().updateManager(manager);
+        then(contractRepository).should().save(contract);
     }
 
     @Test
-    @DisplayName("updateMatchingStatus - Nominee 없을 경우 예외 발생")
-    void updateMatchingStatus_nomineeNotFound() {
-        when(nomineeRepository.findByContractAndManager(any(), any()))
-                .thenReturn(Optional.empty());
+    void acceptPersonalMatching_개인아니면_예외() {
+        // given
+        given(nomineeRepository.findByContractAndManager(managerId, contractId))
+                .willReturn(Optional.of(nominee));
+        given(managerRepository.findById(managerId)).willReturn(Optional.of(manager));
+        given(contractRepository.findById(contractId)).willReturn(Optional.of(contract));
+        given(contract.isPersonal()).willReturn(false);
 
-        assertThatThrownBy(() -> contractMatchingService.updateMatchingStatus(1L, 1L, MatchingStatus.REJECT))
-                .isInstanceOf(NomineeException.class)
-                .hasMessageContaining(ErrorCode.MATCHING_NOMINEE_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("matchManagerAndCustomer - 개인 계약일 경우 정상 처리")
-    void matchManagerAndCustomer_success() {
-        Long managerId = 1L;
-        Long contractId = 1L;
-
-        Nominee nominee = mock(Nominee.class);
-        Manager manager = mock(Manager.class);
-        Contract contract = mock(Contract.class);
-
-        when(nomineeRepository.findByContractAndManager(managerId, contractId))
-                .thenReturn(Optional.of(nominee));
-        when(managerRepository.findById(managerId)).thenReturn(Optional.of(manager));
-        when(contractRepository.findById(contractId)).thenReturn(Optional.of(contract));
-        when(contract.isPersonal()).thenReturn(true);
-
-        contractMatchingService.matchManagerAndCustomer(managerId, contractId);
-
-        verify(nominee).updateStatus(MatchingStatus.ACCEPT);
-        verify(contract).updateManager(manager);
-        verify(contractRepository).save(contract);
-    }
-
-    @Test
-    @DisplayName("matchManagerAndCustomer - 개인 계약이 아닐 경우 예외 발생")
-    void matchManagerAndCustomer_notPersonalContract() {
-        Nominee nominee = mock(Nominee.class);
-        Manager manager = mock(Manager.class);
-        Contract contract = mock(Contract.class);
-
-        when(nomineeRepository.findByContractAndManager(any(), any()))
-                .thenReturn(Optional.of(nominee));
-        when(managerRepository.findById(any()))
-                .thenReturn(Optional.of(manager));
-        when(contractRepository.findById(any()))
-                .thenReturn(Optional.of(contract));
-        when(contract.isPersonal()).thenReturn(false);
-
-        assertThatThrownBy(() -> contractMatchingService.matchManagerAndCustomer(1L, 1L))
+        // when & then
+        assertThatThrownBy(() -> contractMatchingService.acceptPersonalMatching(managerId, contractId))
                 .isInstanceOf(ContractException.class)
                 .hasMessageContaining(ErrorCode.CONTRACT_BAD_REQUEST.getMessage());
+    }
+
+    @Test
+    void rejectPersonalMatching_정상_호출() {
+        // given
+        given(nomineeRepository.findByContractAndManager(managerId, contractId))
+                .willReturn(Optional.of(nominee));
+
+        // when
+        contractMatchingService.rejectPersonalMatching(managerId, contractId);
+
+        // then
+        then(nominee).should().updateStatus(MatchingStatus.REJECT);
+        then(nomineeRepository).should().save(nominee);
     }
 }

--- a/src/test/java/com/kdev5/cleanpick/contract/service/ContractMatchingServiceTest.java
+++ b/src/test/java/com/kdev5/cleanpick/contract/service/ContractMatchingServiceTest.java
@@ -1,0 +1,106 @@
+package com.kdev5.cleanpick.contract.service;
+
+import com.kdev5.cleanpick.contract.domain.Contract;
+import com.kdev5.cleanpick.contract.domain.Nominee;
+import com.kdev5.cleanpick.contract.domain.enumeration.MatchingStatus;
+import com.kdev5.cleanpick.contract.domain.exception.ContractException;
+import com.kdev5.cleanpick.contract.domain.exception.NomineeException;
+import com.kdev5.cleanpick.contract.infra.ContractRepository;
+import com.kdev5.cleanpick.contract.infra.NomineeRepository;
+import com.kdev5.cleanpick.global.exception.ErrorCode;
+import com.kdev5.cleanpick.manager.domain.Manager;
+import com.kdev5.cleanpick.manager.infra.repository.ManagerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class ContractMatchingServiceTest {
+
+    private NomineeRepository nomineeRepository;
+    private ContractRepository contractRepository;
+    private ManagerRepository managerRepository;
+    private ContractMatchingService contractMatchingService;
+
+    @BeforeEach
+    void setUp() {
+        nomineeRepository = mock(NomineeRepository.class);
+        contractRepository = mock(ContractRepository.class);
+        managerRepository = mock(ManagerRepository.class);
+        contractMatchingService = new ContractMatchingService(nomineeRepository, contractRepository, managerRepository);
+    }
+
+    @Test
+    @DisplayName("updateMatchingStatus - 정상 동작")
+    void updateMatchingStatus_success() {
+        Long managerId = 1L;
+        Long contractId = 1L;
+        Nominee nominee = mock(Nominee.class);
+
+        when(nomineeRepository.findByContractAndManager(managerId, contractId))
+                .thenReturn(Optional.of(nominee));
+
+        contractMatchingService.updateMatchingStatus(managerId, contractId, MatchingStatus.REJECT);
+
+        verify(nominee).updateStatus(MatchingStatus.REJECT);
+        verify(nomineeRepository).save(nominee);
+    }
+
+    @Test
+    @DisplayName("updateMatchingStatus - Nominee 없을 경우 예외 발생")
+    void updateMatchingStatus_nomineeNotFound() {
+        when(nomineeRepository.findByContractAndManager(any(), any()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> contractMatchingService.updateMatchingStatus(1L, 1L, MatchingStatus.REJECT))
+                .isInstanceOf(NomineeException.class)
+                .hasMessageContaining(ErrorCode.MATCHING_NOMINEE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("matchManagerAndCustomer - 개인 계약일 경우 정상 처리")
+    void matchManagerAndCustomer_success() {
+        Long managerId = 1L;
+        Long contractId = 1L;
+
+        Nominee nominee = mock(Nominee.class);
+        Manager manager = mock(Manager.class);
+        Contract contract = mock(Contract.class);
+
+        when(nomineeRepository.findByContractAndManager(managerId, contractId))
+                .thenReturn(Optional.of(nominee));
+        when(managerRepository.findById(managerId)).thenReturn(Optional.of(manager));
+        when(contractRepository.findById(contractId)).thenReturn(Optional.of(contract));
+        when(contract.isPersonal()).thenReturn(true);
+
+        contractMatchingService.matchManagerAndCustomer(managerId, contractId);
+
+        verify(nominee).updateStatus(MatchingStatus.ACCEPT);
+        verify(contract).updateManager(manager);
+        verify(contractRepository).save(contract);
+    }
+
+    @Test
+    @DisplayName("matchManagerAndCustomer - 개인 계약이 아닐 경우 예외 발생")
+    void matchManagerAndCustomer_notPersonalContract() {
+        Nominee nominee = mock(Nominee.class);
+        Manager manager = mock(Manager.class);
+        Contract contract = mock(Contract.class);
+
+        when(nomineeRepository.findByContractAndManager(any(), any()))
+                .thenReturn(Optional.of(nominee));
+        when(managerRepository.findById(any()))
+                .thenReturn(Optional.of(manager));
+        when(contractRepository.findById(any()))
+                .thenReturn(Optional.of(contract));
+        when(contract.isPersonal()).thenReturn(false);
+
+        assertThatThrownBy(() -> contractMatchingService.matchManagerAndCustomer(1L, 1L))
+                .isInstanceOf(ContractException.class)
+                .hasMessageContaining(ErrorCode.CONTRACT_BAD_REQUEST.getMessage());
+    }
+}


### PR DESCRIPTION
# Pull Request
## 📝 PR 설명

- 매니저가 요청을 관리하는 기능을 개발했습니다.
- 알고리즘 기반 수락, 1:1 수락, 거절 3가지로 나누려고 했으나, 기본 수락과 거절은 status만 변경하면 되기 때문에 하나의 api로 구현하였습니다.
- 단, 1:1 요청 수락의 경우에는 (계약에 정보 저장하는) 추가 서비스 로직이 필요하기 때문에 분리하였습니다.
- 응답이 필요 없다고 판단, 빈 응답값을 보낼 수 있는 ApiResponse를 추가하였습니다.

---

## ✅ 작업 내용 체크리스트

- [x] 새로운 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 문서/README 수정

---

## 🔍 관련 이슈

- resolves #31

---

## 🧩 참고 자료 (선택)

- API 명세서, 디자인 링크, 노션 문서 등